### PR TITLE
[FIX] hr_holidays: Reset interface-based fields on leave mode change

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -244,16 +244,16 @@ class HolidaysAllocation(models.Model):
 
     @api.onchange('holiday_type')
     def _onchange_type(self):
+        self.employee_id = None
+        self.department_id = None
+        self.category_id = None
+        self.mode_company_id = None
         if self.holiday_type == 'employee' and not self.employee_id:
             if self.env.user.employee_ids:
                 self.employee_id = self.env.user.employee_ids[0]
         elif self.holiday_type == 'department':
             if self.env.user.employee_ids:
                 self.department_id = self.department_id or self.env.user.employee_ids[0].department_id
-            self.employee_id = None
-        elif self.holiday_type == 'category':
-            self.employee_id = None
-            self.department_id = None
 
     @api.onchange('employee_id')
     def _onchange_employee(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
When creating new leave, request mode is set By Employee and employee is selected automatically. After selecting mode By Company employee in field employee_id stay selected (field becomes invisible). If employee is part of selected company this procedure will lead to wrong request days, employee will get double requested amount.  Reset fields (employee, department, company, employee tag) when change model will remove this type of mistake.

Current behavior before PR: 
After changing mode fields employee, department, company and employee tag becomes invisible depending on mode selected, but value inside them stays which lead to wrong request days in some cases (e.g. If we create leave request mode is By Employee and employee is set by automatically, when we change to mode to By Company, field employee becomes invisible but value stays which lead to wrong request days). 

Desired behavior after PR is merged:
Reset field employee, department, company and employee tag, at the beginning onchange method to avoid this type of mistake




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
